### PR TITLE
ビルド前にswiftlint autocorrect を実行するようにした

### DIFF
--- a/HatebLine.xcodeproj/project.pbxproj
+++ b/HatebLine.xcodeproj/project.pbxproj
@@ -314,6 +314,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 55415B901C3961F90079B118 /* Build configuration list for PBXNativeTarget "HatebLine" */;
 			buildPhases = (
+				9067CE921F315E6400B097D4 /* ShellScript */,
 				55415B661C3961F90079B118 /* Sources */,
 				55415B671C3961F90079B118 /* Frameworks */,
 				55415B681C3961F90079B118 /* Resources */,
@@ -437,6 +438,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		9067CE921F315E6400B097D4 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint autocorrect'\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		55415B661C3961F90079B118 /* Sources */ = {

--- a/README.org
+++ b/README.org
@@ -9,7 +9,7 @@ OS X 10.11+
 
 ** Build
 
-First, install [[https://github.com/Carthage/Carthage][Carthage]]. (If you use [[http://brew.sh/][Homebrew]], just 'brew install carthage')
+First, install [[https://github.com/Carthage/Carthage][Carthage]] and [[SwiftLint][https://github.com/realm/SwiftLint]]. (If you use [[http://brew.sh/][Homebrew]], just 'brew install carthage swiftlint')
 
 And then, do
 #+BEGIN_SRC sh


### PR DESCRIPTION
ソースコードの整形を強制するために、ビルド前にswiftlint autocorrectを実行するようにしました。

# 欠点

ビルドに時間がかかる(12秒ぐらい増加した)

# 欠点を解決する別の方法

* gulp.watchなどファイルシステムの監視して実行する系で実行する
  * 欠点 整形を強制することができない
* Xcodeのプラグインで保存時に実行する
  * 欠点 整形を強制することができない

マージする場合は #13 を先にマージすることをおすすめします

issue #12 